### PR TITLE
Fix comparison link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Colorize your output in a terminal with clean syntax,
 e.g., ``` green`Hello World!` ``` ``` red`Error!` ``` ``` black.bgYellow`Warning!` ```.
 
 **Why yet one lib?**\
-See [comparison](https://github.com/webdiscus/ansis#compare-most-popular-ansi-libraries)
+See [comparison](https://github.com/webdiscus/ansis#compare)
 and [benchmarks](https://github.com/webdiscus/ansis#benchmark) of most popular Node.js libraries:\
 [`chalk`][chalk], [`colors.js`][colors.js], [`colorette`][colorette], [`picocolors`][picocolors], [`kleur`][kleur], [`ansi-colors`][ansi-colors], [`cli-color`][cli-color], [`colors-cli`][colors-cli].
 


### PR DESCRIPTION


## Types of changes

<!-- Please place an `x` in all [ ] that apply: -->

This PR contains a:

- [x] **typo fix**
- [x] **docs change**

## Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

The link in the README (to another section of the README) was broken, a click did nothing.

## Additional Info

It looks like this got broken in f88ed87341ecb454cb8abe1d630d43ff2b04316d.

## Checklist

<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->

- [ ] I have read the **CONTRIBUTING** document.

No, there is none?

