### PR TITLE
fix: use function overload to make the tagged template have the correct type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,8 @@ interface Ansis {
    *
    * @param {string | TemplateStringsArray} string
    */
-  (string: string | TemplateStringsArray): string;
+  (string: string): string;
+  (string: TemplateStringsArray, ...parameters: string[]): string;
 
   /**
    * Set [256-color ANSI code](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) for foreground color.


### PR DESCRIPTION
## Types of changes

<!-- Please place an `x` in all [ ] that apply: -->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **docs change**
- [ ] **breaking change** <!-- fix or feature that change existing functionality -->

## Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Without this TypeScript complains when using the tagged template literal with the error:

> error TS2554: Expected 1 arguments, but got 2

## Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

None

## Additional Info

---

## Checklist

<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG.md**.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
