### PR TITLE
fix: correct colorspace detection for deno 2.0+

### DIFF
--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -545,15 +545,13 @@ describe('FORCE_COLOR', () => {
 
   test(`isTTY false, FORCE_COLOR=1`, () => {
     const received = colorSpace({
-      Deno: {
-        env: {
-          toObject: () => ({ FORCE_COLOR: 1 }),
-        },
-        args: [],
-        build: {
-          os: 'linux',
-        },
-        isatty: (rid) => false, // analog to process.stdout.isTTY in node
+      Deno: {},
+      process: {
+        platform: 'linux',
+        env: { FORCE_COLOR: 1 },
+        argv: [],
+        stdout: { isTTY: false },
+        stderr: { isTTY: false },
       },
     });
     const expected = SPACE_16COLORS;
@@ -948,17 +946,14 @@ describe('Node.JS different env', () => {
 describe('Deno support', () => {
   test(`env TERM`, () => {
     const received = colorSpace({
-      Deno: {
-        env: {
-          toObject: () => ({ TERM: 'xterm-256color' }),
-        },
-        args: [],
-        build: {
-          os: 'linux', // win32
-        },
-        isatty: (rid) => rid === 1, // analog to process.stdout.isTTY in node
+      Deno: {},
+      process: {
+        platform: 'linux',
+        env: { TERM: 'xterm-256color' },
+        argv: [],
+        stdout: { isTTY: true },
+        stderr: { isTTY: true },
       },
-
     });
     const expected = SPACE_256COLORS;
     expect(received).toEqual(expected);
@@ -966,20 +961,16 @@ describe('Deno support', () => {
 
   test(`no permissions`, () => {
     const received = colorSpace({
-      Deno: {
-        env: {
-          toObject: () => {
-            // throw error to simulate no permission
-            throw new Error('np permissions');
-          },
+      Deno: {},
+      process: {
+        platform: 'linux',
+        get env() {
+          throw new Error('No permissions');
         },
-        args: [],
-        build: {
-          os: 'linux',
-        },
-        isatty: (rid) => rid === 1, // analog to process.stdout.isTTY in node
+        argv: [],
+        stdout: { isTTY: true },
+        stderr: { isTTY: true },
       },
-
     });
     const expected = SPACE_BW;
     expect(received).toEqual(expected);
@@ -987,37 +978,29 @@ describe('Deno support', () => {
 
   test(`platform win`, () => {
     const received = colorSpace({
-      Deno: {
-        env: {
-          toObject: () => ({ TERM: '' }),
-        },
-        args: [],
-        build: {
-          os: 'win32',
-        },
-        isatty: (rid) => true, // analog to process.stdout.isTTY in node
+      Deno: {},
+      process: {
+        platform: 'win32',
+        env: { TERM: '' },
+        argv: [],
+        stdout: { isTTY: true },
+        stderr: { isTTY: true },
       },
-
     });
     const expected = SPACE_TRUECOLOR;
     expect(received).toEqual(expected);
   });
 
-
-
   test(`flag '--color'`, () => {
     const received = colorSpace({
-      Deno: {
-        env: {
-          toObject: () => ({}),
-        },
-        args: ['--color'],
-        build: {
-          os: 'linux',
-        },
-        isatty: (rid) => false, // analog to process.stdout.isTTY in node
+      Deno: {},
+      process: {
+        platform: 'linux',
+        env: {},
+        argv: ['--color'],
+        stdout: { isTTY: false },
+        stderr: { isTTY: false },
       },
-
     });
     const expected = SPACE_TRUECOLOR;
     expect(received).toEqual(expected);


### PR DESCRIPTION
## Types of changes

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **docs change**
- [ ] **breaking change** <!-- fix or feature that change existing functionality -->

## Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

In deno version 2.0 and greater, the `process` global is available. This breaks the color space detection logic, as it tries to call `toObject()` on `process.env`.

As of deno 2, it is now node compatible and shouldn't require the use of any deno-specific APIs.

## Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

## Additional Info

This PR removes the special handling for deno in general, but retains the try catch to handle when env var permissions are denied.

---

## Checklist

<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the **CHANGELOG.md**.
- [ ] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Appreciation for the useful project

- [ ] Do not forget to give a star ⭐
